### PR TITLE
Fix yume2kki-t menu themes web scraper

### DIFF
--- a/app.js
+++ b/app.js
@@ -2684,6 +2684,8 @@ function addMenuThemeDataJPMethods(menuThemeData, removed) {
 
             for (let m = 0; m < menuThemeDataRows.length; m++) {
                 const data = menuThemeDataRows[m].split('</td><td').slice(0, 2);
+                if (!data.length || data[0].indexOf('<th') > -1)
+                    continue; // skip the page headers (1ページ目, 2ページ目, etc.)
                 if (data[1].indexOf('</table>') > -1) {
                     m++;
                     endOfTable = true;


### PR DESCRIPTION
Since the menu themes page on wikiwiki.jp/yume2kki-t has added page delimiters, this breaks the scraper bringing down the worker itself. This is a temporary fix until a regex-based method similar to addWallpaperDataJPMethods is added.